### PR TITLE
Add rezn_free function to free allocated memory for canonicalized JSON

### DIFF
--- a/cpp/reznjcs.cpp
+++ b/cpp/reznjcs.cpp
@@ -32,3 +32,8 @@ extern "C" const char *rezn_canonicalize(const char *json_utf8)
         return nullptr;
     }
 }
+
+extern "C" void rezn_free(char *ptr)
+{
+    free(ptr);
+}

--- a/cpp/reznjcs.h
+++ b/cpp/reznjcs.h
@@ -7,6 +7,8 @@ extern "C"
     // Caller must free() the result.
     const char *rezn_canonicalize(const char *json_utf8);
 
+    void rezn_free(char *ptr);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new function to allow users to safely free memory allocated by the library. This improves memory management for applications using the library's string allocation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->